### PR TITLE
Support checksums

### DIFF
--- a/src/main/java/edu/colorado/cires/cmg/s3out/FileMockS3ClientMultipartUpload.java
+++ b/src/main/java/edu/colorado/cires/cmg/s3out/FileMockS3ClientMultipartUpload.java
@@ -86,17 +86,28 @@ public class FileMockS3ClientMultipartUpload implements S3ClientMultipartUpload 
 
   @Override
   public CompletedPart uploadPart(String bucket, String key, String uploadId, int partNumber, ByteBuffer buffer) {
-    MultipartUploadState multipartUploadState = uploadStateMap.get(uploadId);
-    if (!multipartUploadState.getBucket().equals(bucket)) {
-      throw new IllegalStateException("Incorrect bucket: " + bucket + " : " + multipartUploadState.getBucket());
+    return uploadPart(UploadPartParams.builder()
+            .bucket(bucket)
+            .key(key)
+            .uploadId(uploadId)
+            .partNumber(partNumber)
+            .buffer(buffer)
+            .build());
+  }
+
+  @Override
+  public CompletedPart uploadPart(UploadPartParams uploadPartParams) {
+    MultipartUploadState multipartUploadState = uploadStateMap.get(uploadPartParams.getUploadId());
+    if (!multipartUploadState.getBucket().equals(uploadPartParams.getBucket())) {
+      throw new IllegalStateException("Incorrect bucket: " + uploadPartParams.getBucket() + " : " + multipartUploadState.getBucket());
     }
-    if (!multipartUploadState.getKey().equals(key)) {
-      throw new IllegalStateException("Incorrect key: " + key + " : " + multipartUploadState.getKey());
+    if (!multipartUploadState.getKey().equals(uploadPartParams.getKey())) {
+      throw new IllegalStateException("Incorrect key: " + uploadPartParams.getKey() + " : " + multipartUploadState.getKey());
     }
-    if (partNumber != multipartUploadState.getParts().size() + 1) {
-      throw new IllegalStateException("Incorrect part number: " + partNumber + " : " + (multipartUploadState.getParts().size() + 1));
+    if (uploadPartParams.getPartNumber() != multipartUploadState.getParts().size() + 1) {
+      throw new IllegalStateException("Incorrect part number: " + uploadPartParams.getPartNumber() + " : " + (multipartUploadState.getParts().size() + 1));
     }
-    multipartUploadState.getParts().add(buffer);
+    multipartUploadState.getParts().add(uploadPartParams.getBuffer());
     return CompletedPart.builder().build();
   }
 

--- a/src/main/java/edu/colorado/cires/cmg/s3out/MultipartUploadRequest.java
+++ b/src/main/java/edu/colorado/cires/cmg/s3out/MultipartUploadRequest.java
@@ -16,11 +16,13 @@ public class MultipartUploadRequest {
 
   private final String bucket;
   private final String key;
+  private final String checksumAlgorithm;
   private final ObjectMetadataCustomizer objectMetadata;
 
-  private MultipartUploadRequest(String bucket, String key, ObjectMetadataCustomizer objectMetadata) {
+  private MultipartUploadRequest(String bucket, String key, String checksumAlgorithm, ObjectMetadataCustomizer objectMetadata) {
     this.bucket = bucket;
     this.key = key;
+    this.checksumAlgorithm = checksumAlgorithm;
     this.objectMetadata = objectMetadata;
   }
 
@@ -43,6 +45,15 @@ public class MultipartUploadRequest {
   }
 
   /**
+   * Returns the checksum algorithm.
+   * Never null.
+   * @return the checksum algorithm
+   */
+  public String getChecksumAlgorithm() {
+    return checksumAlgorithm;
+  }
+
+  /**
    * Returns and {@link Optional} containing a {@link ObjectMetadataCustomizer} if available or an empty {@link Optional} otherwise.
    * @return an {@link Optional}lly wrapped {@link ObjectMetadataCustomizer}
    */
@@ -58,6 +69,7 @@ public class MultipartUploadRequest {
 
     private String bucket;
     private String key;
+    private String checksumAlgorithm;
     private ObjectMetadataCustomizer objectMetadata;
 
     private Builder() {
@@ -87,6 +99,17 @@ public class MultipartUploadRequest {
     }
 
     /**
+     * Sets the checksum algorithm for the {@link MultipartUploadRequest}. Required.
+     *
+     * @param checksumAlgorithm the checksum algorithm
+     * @return this Builder
+     */
+    public Builder checksumAlgorithm(String checksumAlgorithm) {
+      this.checksumAlgorithm = checksumAlgorithm;
+      return this;
+    }
+
+    /**
      * Sets the metadata that will be applied to a file.
      *
      * @param objectMetadata the file metadata
@@ -106,6 +129,7 @@ public class MultipartUploadRequest {
       return new MultipartUploadRequest(
           Objects.requireNonNull(bucket, "bucket is required"),
           Objects.requireNonNull(key, "key is required"),
+          checksumAlgorithm,
           objectMetadata);
     }
   }

--- a/src/main/java/edu/colorado/cires/cmg/s3out/ObjectMetadata.java
+++ b/src/main/java/edu/colorado/cires/cmg/s3out/ObjectMetadata.java
@@ -834,7 +834,9 @@ public class ObjectMetadata implements ObjectMetadataCustomizer {
      *
      * @param checksumAlgorithm Indicates the algorithm you want Amazon S3 to use to create the checksum for the object.
      * @return this Builder
+     * @deprecated Use {@link MultipartUploadRequest.Builder#checksumAlgorithm(String)} instead
      */
+    @Deprecated
     public Builder checksumAlgorithm(String checksumAlgorithm) {
       this.checksumAlgorithm = checksumAlgorithm;
       return this;

--- a/src/main/java/edu/colorado/cires/cmg/s3out/S3ClientMultipartUpload.java
+++ b/src/main/java/edu/colorado/cires/cmg/s3out/S3ClientMultipartUpload.java
@@ -51,8 +51,19 @@ public interface S3ClientMultipartUpload {
    * @param partNumber the incrementing number for this part in the upload
    * @param buffer a {@link ByteBuffer} containing the data to be uploaded in this part
    * @return a {@link CompletedPart} response object from the completed part upload
+   * @deprecated Replaced by {@link #uploadPart(UploadPartParams)}
    */
   CompletedPart uploadPart(String bucket, String key, String uploadId, int partNumber, ByteBuffer buffer);
+
+  /**
+   * Uploads a part of a multipart upload.
+   *
+   * @param uploadPartParams details for the upload: bucket, key, metadata, etc.
+   * @return a {@link CompletedPart} response object from the completed part upload
+   */
+  default CompletedPart uploadPart(UploadPartParams uploadPartParams) {
+    return uploadPart(uploadPartParams.getBucket(), uploadPartParams.getKey(), uploadPartParams.getUploadId(), uploadPartParams.getPartNumber(), uploadPartParams.getBuffer());
+  }
 
   /**
    * Triggers completion of the multipart upload.

--- a/src/main/java/edu/colorado/cires/cmg/s3out/UploadPartParams.java
+++ b/src/main/java/edu/colorado/cires/cmg/s3out/UploadPartParams.java
@@ -1,0 +1,190 @@
+package edu.colorado.cires.cmg.s3out;
+
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+public class UploadPartParams {
+
+  /**
+   * Creates a new builder for a UploadPartParams.
+   *
+   * @return a new builder for a UploadPartParams
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  private final String bucket;
+  private final String key;
+  private final String uploadId;
+  private final int partNumber;
+  private final ByteBuffer buffer;
+  private final String checksumAlgorithm;
+
+  public UploadPartParams(String bucket, String key, String uploadId, int partNumber, ByteBuffer buffer, String checksumAlgorithm) {
+    this.bucket = bucket;
+    this.key = key;
+    this.uploadId = uploadId;
+    this.partNumber = partNumber;
+    this.buffer = buffer;
+    this.checksumAlgorithm = checksumAlgorithm;
+  }
+
+  /**
+   * Returns the bucket name.
+   * Never null.
+   *
+   * @return the bucket name
+   */
+  public String getBucket() {
+    return bucket;
+  }
+
+  /**
+   * Returns the bucket key
+   * Never null.
+   *
+   * @return the bucket key
+   */
+  public String getKey() {
+    return key;
+  }
+
+  /**
+   * Returns the upload id
+   * Never null.
+   *
+   * @return the upload id
+   */
+  public String getUploadId() {
+    return uploadId;
+  }
+
+  /**
+   * Returns the part number
+   * Never null.
+   *
+   * @return the part number
+   */
+  public int getPartNumber() {
+    return partNumber;
+  }
+
+  /**
+   * Returns the buffer
+   * Never null.
+   *
+   * @return the buffer
+   */
+  public ByteBuffer getBuffer() {
+    return buffer;
+  }
+
+  /**
+   * Returns the checksumAlgorithm;
+   *
+   * @return the checksumAlgorithm
+   */
+  public String getChecksumAlgorithm() {
+    return checksumAlgorithm;
+  }
+
+
+  /**
+   * Builds a {@link UploadPartParams}.
+   */
+  public static class Builder {
+
+    private String bucket;
+    private String key;
+    private String uploadId;
+    private int partNumber;
+    private ByteBuffer buffer;
+    private String checksumAlgorithm;
+
+    private Builder() {
+
+    }
+
+    /**
+     * Sets the bucket name for the {@link UploadPartParams}. Required.
+     *
+     * @param bucket the bucket name
+     * @return this Builder
+     */
+    public Builder bucket(String bucket) {
+      this.bucket = bucket;
+      return this;
+    }
+
+    /**
+     * Sets the key where the file will be uploaded to in the bucket. Required.
+     *
+     * @param key the key where the file will be uploaded to in the bucket
+     * @return this Builder
+     */
+    public Builder key(String key) {
+      this.key = key;
+      return this;
+    }
+
+    /**
+     * Sets the upload id. Required.
+     *
+     * @param uploadId the upload id
+     * @return this Builder
+     */
+    public Builder uploadId(String uploadId) {
+      this.uploadId = uploadId;
+      return this;
+    }
+
+    /**
+     * Sets the part number. Required.
+     *
+     * @param partNumber the part number
+     * @return this Builder
+     */
+    public Builder partNumber(int partNumber) {
+      this.partNumber = partNumber;
+      return this;
+    }
+
+    /**
+     * Sets the buffer. Required.
+     *
+     * @param buffer the buffer
+     * @return this Builder
+     */
+    public Builder buffer(ByteBuffer buffer) {
+      this.buffer = buffer;
+      return this;
+    }
+
+    /**
+     * Sets the checksumAlgorithm that will be applied.
+     *
+     * @param checksumAlgorithm the file metadata
+     * @return this Builder
+     */
+    public Builder checksumAlgorithm(String checksumAlgorithm) {
+      this.checksumAlgorithm = checksumAlgorithm;
+      return this;
+    }
+
+    /**
+     * Builds a new {@link UploadPartParams}
+     *
+     * @return a new {@link UploadPartParams}
+     */
+    public UploadPartParams build() {
+      return new UploadPartParams(
+              Objects.requireNonNull(bucket, "bucket is required"),
+              Objects.requireNonNull(key, "key is required"),
+              Objects.requireNonNull(uploadId, "uploadId is required"),
+              Objects.requireNonNull(partNumber, "partNumber is required"),
+              Objects.requireNonNull(buffer, "buffer is required"),
+              checksumAlgorithm);
+    }
+  }
+}


### PR DESCRIPTION
This PR adds support for checksums. 

Checksum-validations are required for SOC2 compliance.

Related:
- [Amazon S3 checksums with AWS SDK for Java](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/s3-checksums.html)

Changes:
- ObjectMetadata already supports setting the `checksumAlgorithm`, but the setting is only applied to the `CreateMultipartUploadRequest`. The `checksumAlgorithm` also needs to be added to the `UploadPartRequest `. I added the `checksumAlgorithm` explicitly to the `MultipartUploadRequest` and deprecated it in the ObjectMetadata
- Added a `uploadPart`-method with a parameter object (aligned to `createMultipartUpload`, which also uses a parameter object)
- Checksums from the `UploadPartResponse`s are collected in the `CompletedPart`s

Everything should be fully backward-compatible and the use of `checksumAlgorithm` is optional.

What do you think? Helpful?